### PR TITLE
Fix case of FileUtils module to fix issue on Linux boxes

### DIFF
--- a/update.rb
+++ b/update.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/ruby
-require "FileUtils"
+require "fileutils"
 
 pretext = "! Last modified: "
 timestamp = Time.new.gmtime.strftime("%d %B %Y %R %Z")


### PR DESCRIPTION
It looks like that modules loading is case sensitive in Ruby. While it doesn't seem to be an issue on most Mac OS and Windows boxes it is on Linux (http://stackoverflow.com/q/10108485).