### PR TITLE
remove ##.cookies rule

### DIFF
--- a/obtrusive.txt
+++ b/obtrusive.txt
@@ -644,7 +644,6 @@ cdn.iubenda.com/cookie_solution/iubenda_cs.js
 ##.cookieControl
 ##.cookieNotification
 ##.CookieNotification
-##.cookies
 ##.cookies-overlay
 ##.eu-cookie-nag
 ##.eu-cookie-notice


### PR DESCRIPTION
The ##.cookies rule makes many sites not display at all. http://www.svtplay.se/ and http://www.hs.fi/ are two examples I've found.