### PR TITLE
Update new hosting URL for Fucking EU cookies panel

### DIFF
--- a/obtrusive.txt
+++ b/obtrusive.txt
@@ -545,6 +545,7 @@ zumba.com##.privacy-policy
 
 ! Fucking EU cookies script (https://goo.gl/pB2Ayt)
 s3-eu-west-1.amazonaws.com/fucking-eu-cookies/*$script
+d2z9iq901qkqk8.cloudfront.net/*$script
 
 /cookieCompliance.js$script
 


### PR DESCRIPTION
Update new hosting URL for Fucking EU cookies panel, see: jakubboucek/fucking-eu-cookies@868c55138b3104f4c90eb9abef529b185c641f82

Both URL keeps.