### PR TITLE
Add new cookie-popup id

### DIFF
--- a/obtrusive.txt
+++ b/obtrusive.txt
@@ -628,6 +628,7 @@ cdn.iubenda.com/cookie_solution/iubenda_cs.js
 ###aboutCookieUsageBox
 ###AvisoCookieslaw
 ###alert-cookie
+###accept-cookie
 ###block-cookie_policy-0
 ###ca_banner
 ###capaAvisoPoliticaCookies_superior_mensajes


### PR DESCRIPTION
The div id ###accept-cookie is used often for cookie-constent on-hover in hungarian sites, such as:
origo.hu, life.hu, reblog.hu, investor.hu, ok.hu, videa.hu