### PR TITLE
Block cookie notice overlay on theinquirer.net

### DIFF
--- a/obtrusive.txt
+++ b/obtrusive.txt
@@ -455,6 +455,7 @@ tesco.com###tesco_cookie_widget
 theatlantic.com##.cookie-disclaimer
 theguardian.com##.site-message.site-message--cookies
 theiet.org###ietCookiePanel
+theinquirer.net###rdm-cookie-consent
 themeflood.com###gatewayBarFillstacks_in_5416_page4
 thesun.co.uk###sun-cookieMessage
 thesundaytimes.co.uk###tto-cookieMessage


### PR DESCRIPTION
Example of affected page: https://www.theinquirer.net/inquirer/news/3020830/re-scams-an-email-bot-to-waste-scammers-time